### PR TITLE
Add isFlexibleDataRateCapable getter to CanDevice

### DIFF
--- a/packages/linux_can/lib/src/can_device.dart
+++ b/packages/linux_can/lib/src/can_device.dart
@@ -26,6 +26,8 @@ class CanDevice {
   final PlatformInterface _platformInterface;
   final NetworkInterface networkInterface;
 
+  bool get isFlexibleDataRateCapable => _platformInterface.isFlexibleDataRateCapable(networkInterface.name);
+
   CanInterfaceAttributes _queryAttributes({Set<CanInterfaceAttribute>? interests}) {
     return _platformInterface.queryAttributes(networkInterface.index, interests: interests);
   }


### PR DESCRIPTION
We may need to know if a CAN device is FD capable before opening the socket