### PR TITLE
[linux_serial] Fix PlatformInterface.close

### DIFF
--- a/packages/linux_serial/CHANGELOG.md
+++ b/packages/linux_serial/CHANGELOG.md
@@ -1,3 +1,7 @@
+## 0.2.3+8
+
+ - **FIX**: null value assignment in `PlatformInterface.close`.
+
 ## 0.2.3+7
 
  - **FIX**: deprecated use of `dart:ffi` `Pointer.elementAt`. ([0a3213e5](https://github.com/ardera/flutter_packages/commit/0a3213e501c0dbf13667ab1aa6ea4fd635c0ee95))

--- a/packages/linux_serial/lib/src/linux_serial.dart
+++ b/packages/linux_serial/lib/src/linux_serial.dart
@@ -219,7 +219,7 @@ class PlatformInterface {
   final int epollFd;
   final Stream<List<int>> onFdReady;
   final Map<int, ffi.Pointer<epoll_event>?> _epollEventForFd = <int, ffi.Pointer<epoll_event>>{};
-  final Map<int, Computer?> _computerForFd = <int, Computer>{};
+  final Map<int, Computer> _computerForFd = <int, Computer>{};
 
   static PlatformInterface? _instance;
 
@@ -414,7 +414,7 @@ class PlatformInterface {
     assert(_epollEventForFd[fd] != null);
     assert(_computerForFd[fd] != null);
     _computerForFd[fd]!.turnOff();
-    _computerForFd[fd] = null;
+    _computerForFd.remove(fd);
 
     final result = libc.close(fd);
     if (result < 0) {
@@ -422,7 +422,7 @@ class PlatformInterface {
     }
 
     ffi.calloc.free(_epollEventForFd[fd]!);
-    _epollEventForFd[fd] = null;
+    _epollEventForFd.remove(fd);
   }
 }
 

--- a/packages/linux_serial/pubspec.yaml
+++ b/packages/linux_serial/pubspec.yaml
@@ -1,6 +1,6 @@
 name: linux_serial
 description: Dart package for accessing serial ports on Linux using dart:ffi.
-version: 0.2.3+7
+version: 0.2.3+8
 homepage: https://ardera.dev
 repository: https://github.com/ardera/flutter_packages
 


### PR DESCRIPTION
Fix for the Issue: #48 [linux_serial] Exception at PlatformInterface.close
- no nullable `Computer` in the `_computerForFd` Map
- remove the `Computer` and the epoll event on close